### PR TITLE
Update homepage

### DIFF
--- a/src/app/(pages)/[discog]/page.tsx
+++ b/src/app/(pages)/[discog]/page.tsx
@@ -8,7 +8,7 @@ const discographyItem = () => {
   console.log("Discog ID:", discogId);
   return (
     <>
-      <Exhibit id={discogId} fullDescription={true} />
+      <Exhibit id={discogId} fullDescription={true} description={true} cta={true}/>
     </>
   );
 };

--- a/src/app/global.css
+++ b/src/app/global.css
@@ -8,6 +8,8 @@
 
 body {
     font-family: "Roboto Flex", sans-serif;
+    background-color: #ffff;
+    color: #000000;
 }
 
 footer a {

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -15,29 +15,7 @@ const Home = () => {
   return (
     <div className={styles.homepage}>
       <main className={styles.main}>
-        <Exhibit id={featured.id} fullDescription={false} />
-        <DividingLine />
-        <div className={styles.VideoEmbedWrapper}>
-          <VideoEmbed
-            VideoId="iEZd_AXVA9Y"
-            title="'HELLO WORLD!'"
-            ContentType="musicVideo"
-          />
-        </div>
-        <DividingLine />
-        <Subheading text="Want to know who I am?" />
-        <Frame
-          src={"sai"}
-          alt={`3d portrait of SAI`}
-          className={styles.frame}
-        />
-        <div className={styles.ctaWrapper}>
-          <CallToAction
-            CTA="Visit about page"
-            link="/about"
-            className={styles.callToAction}
-          />
-        </div>
+        <Exhibit id={featured.id} description={false} fullDescription={false} cta={false}/>
       </main>
     </div>
   );

--- a/src/app/styles.module.scss
+++ b/src/app/styles.module.scss
@@ -13,12 +13,19 @@
   display: flex;
   flex-direction: column;
   align-items: center;
-  justify-content: center;
-
+  justify-content: flex-start;
+  flex: 1 0 auto;
+  width: 100%;
 }
 
 .main {
   flex-grow: 1;
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: flex-start;
+  padding-bottom: spacings.$DOUBLE;
 }
 
 .frame {

--- a/src/components/Exhibit/index.tsx
+++ b/src/components/Exhibit/index.tsx
@@ -9,7 +9,7 @@ import Subheading from "../Subheading";
 import styles from "./styles.module.scss";
 import { ExhibitProps } from "./types";
 
-const Exhibit = ({ id, fullDescription }: ExhibitProps) => {
+const Exhibit = ({ id, fullDescription, description, cta }: ExhibitProps) => {
   const featured = discography.find((index) => index.id === id);
 
   const altImageText = `Cover art for ${featured!.title}`;
@@ -22,7 +22,7 @@ const Exhibit = ({ id, fullDescription }: ExhibitProps) => {
       <div className={styles.infoPlaque}>
         <Subheading text={featured!.title} />
         <DistroBar id={id} />
-        {fullDescription && (
+        {fullDescription && description && (
           <>
             <p className={styles.infoDetail}>
               <img
@@ -34,7 +34,7 @@ const Exhibit = ({ id, fullDescription }: ExhibitProps) => {
             </p>
           </>
         )}
-        {!fullDescription && (<div className={styles.learnMore}>
+        {!fullDescription && description && (<div className={styles.learnMore}>
             <p className={styles.infoDetail}>
               <img
                 className={styles.infoIcon}
@@ -44,7 +44,7 @@ const Exhibit = ({ id, fullDescription }: ExhibitProps) => {
               {featured?.short}{"..."}
             </p>
             <div className={styles.ctaWrapper}>
-      <CallToAction CTA="Learn more" link={`${id}`}/>
+              {cta && <CallToAction CTA="Learn more" link={`${id}`}/>}
           </div>
     </div>)}
       </div>

--- a/src/components/Exhibit/types.ts
+++ b/src/components/Exhibit/types.ts
@@ -1,5 +1,7 @@
 export type ExhibitProps = {
     id: string;
     fullDescription: boolean;
+    description: boolean;
+    cta: boolean;
   }
   

--- a/src/data/music/discography.json
+++ b/src/data/music/discography.json
@@ -1,5 +1,10 @@
 [
   {
+    "id": "spiritofecstasy",
+    "title": "Spirit of Ecstasy",
+    "releaseDate": "2025-10-23"
+  },
+  {
     "id": "systemsthinking",
     "title": "SYSTEMS THINKING",
     "releaseDate": "2025-03-27",


### PR DESCRIPTION
simplify, to work on later

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds optional description/CTA controls to `Exhibit`, simplifies the homepage to a single `Exhibit`, updates layout/colors, and adds a new discography entry.
> 
> - **Frontend**:
>   - **`Exhibit` component**:
>     - Adds props `description` and `cta`; updates conditional rendering for full/short descriptions and CTA.
>     - Call sites updated: `src/app/(pages)/[discog]/page.tsx` enables both; `src/app/page.tsx` disables both.
>   - **Homepage** (`src/app/page.tsx`): simplified to render only `Exhibit` (removes video/frame/CTA sections).
>   - **Styles**:
>     - `src/app/styles.module.scss`: adjust layout to top-align content, full-width, and add padding.
>     - `src/app/global.css`: set body background and text color.
> - **Data**:
>   - `src/data/music/discography.json`: add `spiritofecstasy` entry with release date.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit dd136bbf55b738cbfd295ac8afed02713f8bbfad. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->